### PR TITLE
Properly configure yarn workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ pnpm-debug.log*
 # OS garbage
 .DS_Store
 Thumbs.db
+.vercel

--- a/apps/first/package.json
+++ b/apps/first/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@demo/first",
+  "version": "0.0.0",
   "description": "First site",
   "private": true,
   "dependencies": {
-    "gatsby": "*"
+    "gatsby": "4.24.4"
   }
 }

--- a/apps/second/package.json
+++ b/apps/second/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@demo/second",
+  "version": "0.0.0",
   "description": "Second site",
   "private": true,
   "dependencies": {
-    "gatsby": "*"
+    "gatsby": "4.24.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nx-gatsby-vercel-starter",
   "private": true,
+  "workspaces": ["apps/*"],
   "description": "Starter for Nx monorepo with multiple Gatsby sites deployed on Vercel",
   "version": "1.0.0",
   "license": "MIT",
@@ -12,7 +13,7 @@
     "typecheck": "nx run-many --target=typecheck"
   },
   "dependencies": {
-    "gatsby": "^4.24.4",
+    "gatsby": "4.24.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "styled-components": "^5.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7883,7 +7883,7 @@ gatsby-worker@^1.24.0:
     "@babel/core" "^7.15.5"
     "@babel/runtime" "^7.15.4"
 
-gatsby@^4.24.4:
+gatsby@4.24.4:
   version "4.24.4"
   resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-4.24.4.tgz#48db456e812cc6ffd1f8180d393a5b01f4a9e03e"
   integrity sha512-jUC5X3xspNKTGp5ADlwP7q1I9kZai9mS+cPkEZJvSetdAB5AZjYY867OxwBgj0awt/E1+f8AG255zanK7Nvwtg==


### PR DESCRIPTION
Sets the `workspace` property in the root-level `package.json` file so that `yarn install` installs all deps, including the ones defined at the root. Additionally, the version of `gatsby` needed to be pinned otherwise there was cryptic build errors due to having multiple copies of gatsby in the node_modules tree.

The project settings are as such:

<img width="923" alt="Screenshot 2023-02-13 at 7 17 33 PM" src="https://user-images.githubusercontent.com/71256/218630343-f40d5cfc-3fc6-4c62-b9d5-2653e2ce3cc4.png">

Example Deployment: https://nx-gatsby-vercel-fsroexou4.vercel-support.app/
Build Logs: https://vercel.com/vercel-support/nx-gatsby-vercel/9mnxjsN9gVD1XCCfckmGvch6vGLy